### PR TITLE
Detect MinGW 32 bit for NO_INTERLOCKEDOR64

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -23,7 +23,7 @@
  * only VC++ 2008 or earlier x86 compilers.
  */
 
-#if (defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1600)
+#if ((defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1600) || (defined(__MINGW32__) && !defined(__MINGW64__)))
 # define NO_INTERLOCKEDOR64
 #endif
 


### PR DESCRIPTION
Builds using 32 bit MinGW will fail, due to the same reasoning described in commit 2d46a44ff24173d2cf5ea2196360cb79470d49c7.

Ran into this issue when I was cross-compiling to win32 using mingw.

[CLA](https://www.openssl.org/policies/cla.html)-url appears to be dead? This might be a trivial change though.